### PR TITLE
Ensure that g:unite_source_session_path is set before accessed

### DIFF
--- a/autoload/unite/sources/session.vim
+++ b/autoload/unite/sources/session.vim
@@ -33,9 +33,8 @@ call unite#util#set_default('g:unite_source_session_default_session_name',
       \ 'default')
 call unite#util#set_default('g:unite_source_session_options',
       \ 'buffers,curdir,folds,help,winsize')
-call unite#get_data_directory()
 call unite#util#set_default('g:unite_source_session_path',
-      \ g:unite_data_directory . '/session')
+      \ unite#get_data_directory() . '/session')
 call unite#util#set_default(
       \ 'g:unite_source_session_enable_beta_features', 0)
 "}}}


### PR DESCRIPTION
Recent updates to unite led to an error in unite-session:

```
:Unite se...                                                                                                                                                                                                                                   
Error detected while processing /home/housl/.vim/bundle/unite-session/autoload/unite/sources/session.vim:                                                                                                                                      
line   37:                                                                                                                                                                                                                                     
E121: Undefined variable: g:unite_data_directory                                                                                                                                                                                               
E116: Invalid arguments for function unite#util#set_default                                                                                                                                                                                    
function <SNR>35_call_unite_empty..unite#start..unite#start#standard..unite#candidates#_recache./ <SNR>137_recache_candidates_loop..<SNR>137_get_source_candidates..177, line 1                                                                 
Vim(let):E121: Undefined variable: g:unite_source_session_path                                                                                                                                                                                 
[unite.vim] Error occured in gather_candidates!                                                                                                                                                                                                
[unite.vim] Source name is session  
```

unite-session should probably call unite#get_data_directory() instead of assuming that the global variable is set, correct? 

Thank you for the awesome plugins.

Jason
