### PR TITLE
Fix inconsistency between code and document

### DIFF
--- a/autoload/unite/sources/session.vim
+++ b/autoload/unite/sources/session.vim
@@ -32,7 +32,7 @@ set cpo&vim
 call unite#util#set_default('g:unite_source_session_default_session_name',
       \ 'default')
 call unite#util#set_default('g:unite_source_session_options',
-      \ 'buffers,curdir,folds,help,winsize')
+      \ 'blank,buffers,curdir,folds,help,tabpages,winsize')
 call unite#util#set_default('g:unite_source_session_path',
       \ unite#get_data_directory() . '/session')
 call unite#util#set_default(


### PR DESCRIPTION
Default value of g:unite_source_session_options is different between code and document.

- [in code](https://github.com/Shougo/unite-session/blob/ae8b51c31e18c38a85d290b1bd23ac2558ca7fe1/autoload/unite/sources/session.vim#L34-L35):     'buffers,curdir,folds,help,winsize'
- [in document](https://github.com/Shougo/unite-session/blob/ae8b51c31e18c38a85d290b1bd23ac2558ca7fe1/doc/unite-session.txt#L80-L81): '**blank**,buffers,curdir,folds,help,**tabpages**,winsize'  

The default value in document  has the same value as [&sessionoptions](https://github.com/vim/vim/blob/80d998cccf1b473cc3c68eb9a7dfd07a1c261074/runtime/doc/options.txt#L6096-L6097)  and I thought that the default value in document came from &sessionoptions, so I changed the default value in code.

Should I change the default value in document?

