### PR TITLE
Ensure Saving of Sessions

### DIFF
--- a/plugin/unite/session.vim
+++ b/plugin/unite/session.vim
@@ -44,7 +44,7 @@ command! -nargs=? -complete=customlist,unite#sources#session#_complete
 if g:unite_source_session_enable_auto_save
   augroup plugin-unite-source-session
     autocmd!
-    autocmd CursorHold *
+    autocmd VimLeave,BufEnter,CursorHold *
           \ if (v:this_session != '' && &filetype !=# 'unite') | call unite#sources#session#_save('') | endif
   augroup END
 endif


### PR DESCRIPTION
When quickly moving between sessions or closing vim before CursorHold was triggered the saved session was not up to date.

I have added some additional events to catch these cases; ok ? 