### PR TITLE
Don't allow the session to be saved when loading

### DIFF
--- a/autoload/unite/sources/session.vim
+++ b/autoload/unite/sources/session.vim
@@ -44,7 +44,7 @@ function! unite#sources#session#define()"{{{
 endfunction"}}}
 
 function! unite#sources#session#_save(filename, ...) "{{{
-  if unite#util#is_cmdwin()
+  if unite#util#is_cmdwin() || exists("s:unite_source_session_loadng")
     return
   endif
 
@@ -150,6 +150,7 @@ function! unite#sources#session#_load(filename) "{{{
     execute 'silent! source' filename
     execute 'silent! bwipeout!' bufnr
   finally
+    let s:unite_source_session_loading=1
     set eventignore=
     doautoall BufRead
     doautoall FileType
@@ -157,6 +158,7 @@ function! unite#sources#session#_load(filename) "{{{
     doautoall BufWinEnter
     doautoall TabEnter
     doautoall SessionLoadPost
+    unlet s:unite_source_session_loading
   endtry
 
   for bufnr in range(1, bufnr('$'))

--- a/autoload/unite/sources/session.vim
+++ b/autoload/unite/sources/session.vim
@@ -150,7 +150,7 @@ function! unite#sources#session#_load(filename) "{{{
     execute 'silent! source' filename
     execute 'silent! bwipeout!' bufnr
   finally
-    let s:unite_source_session_loading=1
+    let s:unite_source_session_loading = 1
     set eventignore=
     doautoall BufRead
     doautoall FileType


### PR DESCRIPTION
If the session is loading then it will activate the BufEnter auto
command. If the sessions are being automatically saved then whilst
loading the session will unnecessarily save the session.